### PR TITLE
Add get_history feature for Deribit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,7 @@ The application doubles up as a normal websocket client in addition to being abl
 3. `DERIBIT <id> get_open_orders` gets all the open orders on the account of this connection. The command can be further specialised as `DERIBIT get_open_orders <currency>`, `DERIBIT get_open_orders <instrument>` and `DERIBIT get_open_orders <currency> <label>`.
 **NOTE** To use this command you will have to modify your API key scope to have `trade:read` or `read_write`.
 
-4. `DERIBIT <id> modify <order_id>` allows you to modify the order with the given order ID. The order ID can be gotten either by noting it down from the received message while placing the order, or later can be retrieved using the `get_open_orders` command.
-5. `DERIBIT <id> cancel <order_id>` allows you to cancel a specific order while `DERIBIT <id> cancel_all <options>` allows you to cancel all orders with the given specification of instrument or currency. Specifying no options in `cancel_all` cancels all possible open orders.
+5. `DERIBIT <id> get_history <currency| instrument>` fetches all recent order history related to a given currency or instrument.
+
+5. `DERIBIT <id> modify <order_id>` allows you to modify the order with the given order ID. The order ID can be gotten either by noting it down from the received message while placing the order, or later can be retrieved using the `get_open_orders` command.
+6. `DERIBIT <id> cancel <order_id>` allows you to cancel a specific order while `DERIBIT <id> cancel_all <options>` allows you to cancel all orders with the given specification of instrument or currency. Specifying no options in `cancel_all` cancels all possible open orders.

--- a/deribot.cpp
+++ b/deribot.cpp
@@ -387,6 +387,7 @@ int main(){
             << "> DERIBIT <id> buy <instrument> <comments>: Sends a buy order via the connection with id <id> for the instrument specified\n"
             << "> DERIBIT <id> sell <instrument> <comments>: Sends a sell order via the connection with id <id> for the instrument specified\n"
             << "> DERIBIT <id> get_open_orders {options}: Gets all the open orders\n"
+            << "> DERIBIT <id> get_order_history {options}: Gets the order history\n"
             << "> DERIBIT <id> modify <order_id>: Allows you to modify the price and amount of an active order with known order id"
             << "> DERIBIT <id> cancel <order_id>: Allows you to cancel a specific order"
             << std::endl;

--- a/src/deribit_api.cpp
+++ b/src/deribit_api.cpp
@@ -264,28 +264,32 @@ std::string deribit_api::get_history(const std::string &input) {
     int id;
     std::string cmd;
     std::string opt1;
-    is >> id >> cmd >> opt1;
+    is >> id >> cmd >> instrument_or_currency;
 
-    jsonrpc j;
-
-    if (opt1 == "") {
+    
+    if (instrument_or_currency == "") {
         utils::printerr("Usage: DERIBIT <id> get_history <currency|instrument>\n");
         return "";
     }
-    // if opt1 is NOT a supported currency => treat as instrument
-    if(std::find(SUPPORTED_CURRENCIES.begin(),
+
+    jsonrpc j;
+
+    // check instrument_or_currency is present in supported currency 
+    const bool is_currency = std::find(SUPPORTED_CURRENCIES.begin(),
                  SUPPORTED_CURRENCIES.end(),
-                opt1) == SUPPORTED_CURRENCIES.end()) {
-        j["method"] = "private/get_order_history_by_instrument";
+                instrument_or_currency) != SUPPORTED_CURRENCIES.end();
+
+    if (is_currency) {
+        j["method"] = "private/get_order_history_by_currency";
         j["params"] = {
-            {"instrument_name", opt1},
+            {"currency", instrument_or_currency},
             {"count", 20}
         };
     }
     else {
-        j["method"] = "private/get_order_history_by_currency";
+        j["method"] = "private/get_order_history_by_instrument";
         j["params"] = {
-            {"currency", opt1},
+            {"instrument_name", instrument_or_currency},
             {"count", 20}
         };
     }

--- a/src/deribit_api.cpp
+++ b/src/deribit_api.cpp
@@ -23,6 +23,7 @@ std::string deribit_api::process(const std::string &input) {
         {"sell", deribit_api::sell},
         {"buy", deribit_api::buy},
         {"get_open_orders", deribit_api::get_open_orders},
+        {"get_history", deribit_api::get_history},
         {"modify", deribit_api::modify},
         {"cancel", deribit_api::cancel}
     };
@@ -257,6 +258,39 @@ std::string deribit_api::get_open_orders(const std::string &input) {
     return j.dump();
 }
 
+std::string deribit_api::get_history(const std::string &input) {
+    std::istringstream is(input);
+    
+    int id;
+    std::string cmd;
+    std::string opt1;
+    is >> id >> cmd >> opt1;
+
+    jsonrpc j;
+
+    if (opt1 == "") {
+        utils::printerr("Usage: DERIBIT <id> get_history <currency|instrument>\n");
+        return "";
+    }
+    // if opt1 is NOT a supported currency => treat as instrument
+    if(std::find(SUPPORTED_CURRENCIES.begin(),
+                 SUPPORTED_CURRENCIES.end(),
+                opt1) == SUPPORTED_CURRENCIES.end()) {
+        j["method"] = "private/get_order_history_by_instrument";
+        j["params"] = {
+            {"instrument_name", opt1},
+            {"count", 20}
+        };
+    }
+    else {
+        j["method"] = "private/get_order_history_by_currency";
+        j["params"] = {
+            {"currency", opt1},
+            {"count", 20}
+        };
+    }
+    return j.dump();
+}
 std::string deribit_api::modify(const std::string &input) {
     std::istringstream is;
 

--- a/src/deribit_api.h
+++ b/src/deribit_api.h
@@ -40,6 +40,8 @@ namespace deribit_api {
 
     std::string get_open_orders(const std::string &input);
 
+    std::string get_history(const std::string &input);
+    
     std::string modify(const std::string &input);
 
     std::string cancel(const std::string &input);


### PR DESCRIPTION
Fixes #5 
This PR adds the `get_history `function in `deribit_api`, to fetch historical orders with currency or instrument.

Changes:

1. Added `get_history(const std::string &input)` in `src/deribit_api.cpp` to get recent orders.
2. Added new `get_history() `API in `src/deribit_api.h`
3. Updated CLI help output for new `DERIBIT <id> get_history<currency|instrument>` command
4. Changed name of `opt1` to `instrument_or_currency` as mentioned.
5. Changed currency detection logic for more clarity
